### PR TITLE
Changed template to use single curly braces.

### DIFF
--- a/pelican_alias.py
+++ b/pelican_alias.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class AliasGenerator(object):
     TEMPLATE = """<!DOCTYPE html><html><head><meta charset="utf-8" />
-<meta http-equiv="refresh" content="0;url=/{{destination_path}}" />
+<meta http-equiv="refresh" content="0;url=/{destination_path}" />
 </head></html>"""
 
     def __init__(self, context, settings, path, theme, output_path, *args):


### PR DESCRIPTION
Not sure what's going on, but, for me, .format() only works with single curly braces. With the double curly braces, all redirects go to the actual literal URL `/{destination_path}`.