### PR TITLE
Generate aliases for hidden pages

### DIFF
--- a/pelican_alias.py
+++ b/pelican_alias.py
@@ -42,7 +42,9 @@ class AliasGenerator(object):
             fd.write(self.TEMPLATE.format(destination_path=page.url))
 
     def generate_output(self, writer):
-        pages = self.context['pages'] + self.context['articles']
+        pages = (
+            self.context['pages'] + self.context['articles'] +
+            self.context.get('hidden_pages', []))
 
         for page in pages:
             aliases = page.metadata.get('alias', [])


### PR DESCRIPTION
https://github.com/getpelican/pelican/pull/1760 updates Pelican to export hidden pages in the context, as well as other pages.

Hiding pages is commonly used to prevent pages appearing in the navbar, while still making them accessible through other links. This means that they need aliases just as much as their unhidden cousins.

This patch will add `hidden_pages` from the context if present, while leaving behaviour unchanged for older versions of pelican.

I've verified that it works on my local pelican blog.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nitron/pelican-alias/12)
<!-- Reviewable:end -->
